### PR TITLE
[iOS] Sends Base 64 encoded image as URI if not saving to camera roll

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -524,6 +524,12 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
                                     //NSLog( @"Could not save to camera roll");
                                 }
                             }];
+                        } else {
+                            NSString *encodedString = [imageData base64Encoding];
+                            imageInfoDict[@"uri"] = [NSString stringWithFormat:@"data:image/jpg;base64,%@", encodedString];
+                            if (block) {
+                                block(imageInfoDict);
+                            }
                         }
                         
                         


### PR DESCRIPTION
When using `camera.capture(false)` the photo will return as data-uri