### PR TITLE
When removing camera view, reset current camera

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/camera/CameraViewManager.java
+++ b/android/src/main/java/com/wix/RNCameraKit/camera/CameraViewManager.java
@@ -131,6 +131,7 @@ public class CameraViewManager extends SimpleViewManager<CameraView> {
         } else if(camera != null){
             camera.release();
             camera = null;
+            currentCamera = 0;
         }
     }
 


### PR DESCRIPTION
When removing the view we need to reset the current camera view or else next time you render a camera view you'll be using the previous camera.

Context:
I would love to be able to pass "front" or "back" in camera options (I'll file request for this). But I found a workaround right now which is to assume I default to front, and when I mount my camera view on `componentDidMount` I call `changeCamera`. However without this PR each time I leave my camera scene and come back I am on the previous camera and I keep toggling which I need to view. 