### PR TITLE
iOS: Release imageRef in snapStillImage

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -534,6 +534,8 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
                         }
                     }
                 }];
+                
+                CGImageRelease(imageRef);
             }
             else {
                 //NSLog( @"Could not capture still image: %@", error );


### PR DESCRIPTION
unreleased imageRef causes a memory leak of about 8 MB after every photo, which finally leads to the crash of the app