### PR TITLE
Fix android crashing on CameraKitGalleryView

### DIFF
--- a/src/CameraKitGalleryView.android.js
+++ b/src/CameraKitGalleryView.android.js
@@ -28,7 +28,7 @@ export default class CameraKitGalleryView extends Component {
   }
 
   render() {
-    const transformedProps = {...this.props};
+    const transformedProps = _.cloneDeep(this.props);
     transformedProps.albumName = this.props.albumName ? this.props.albumName : ALL_PHOTOS;
     if (transformedProps.fileTypeSupport && transformedProps.fileTypeSupport.unsupportedImage) {
       _.update(transformedProps, 'fileTypeSupport.unsupportedImage', (image) => resolveAssetSource(image).uri);

--- a/src/CameraKitGalleryView.ios.js
+++ b/src/CameraKitGalleryView.ios.js
@@ -15,7 +15,7 @@ const resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSou
 
 export default class CameraKitGalleryView extends Component {
   render() {
-    const transformedProps = {...this.props};
+    const transformedProps = _.cloneDeep(this.props);
     transformedProps.albumName = this.props.albumName ? this.props.albumName : ALL_PHOTOS;
     transformedProps.columnCount = this.props.columnCount && this.props.columnCount > 0 ? this.props.columnCount : DEFAULT_COLUMN_COUNT;
     _.update(transformedProps, 'fileTypeSupport.unsupportedOverlayColor', (c) => processColor(c));
@@ -26,19 +26,19 @@ export default class CameraKitGalleryView extends Component {
     if (_.get(transformedProps, 'customButtonStyle.image')) {
       _.update(transformedProps, 'customButtonStyle.image', (image) => resolveAssetSource(image));
     }
-  
+
     if (_.get(transformedProps, 'customButtonStyle.backgroundColor')) {
       _.update(transformedProps, 'customButtonStyle.backgroundColor', (c) => processColor(c));
     }
-  
+
     if (_.get(transformedProps, 'selection.selectedImage')) {
       _.update(transformedProps, 'selection.selectedImage', (image) => resolveAssetSource(image));
     }
-  
+
     if (_.get(transformedProps, 'selection.unselectedImage')) {
       _.update(transformedProps, 'selection.unselectedImage', (image) => resolveAssetSource(image));
     }
-    
+
     if (_.get(transformedProps, 'selection.overlayColor')) {
       _.update(transformedProps, 'selection.overlayColor', (c) => processColor(c));
     }


### PR DESCRIPTION
`CameraKitGalleryView` component did only shallow copy of its props and then proceeded to mutate them with `_.update`. This lead to the component crashing on second render, because the original props have been lost during `_.update`.

```
import openCameraImage from './../assets/camera/openCamera.png'

const customButtonImage = {
  image: openCameraImage,
}

<CameraKitGalleryView
  ...lots of props
  customButtonStyle={customButtonImage}
/>
```