### PR TITLE
Fix crash when changing flash mode on front camera

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/camera/CameraViewManager.java
+++ b/android/src/main/java/com/wix/RNCameraKit/camera/CameraViewManager.java
@@ -54,7 +54,8 @@ public class CameraViewManager extends SimpleViewManager<CameraView> {
             return false;
         }
         Camera.Parameters parameters = camera.getParameters();
-        if(parameters.getSupportedFlashModes().contains(mode)) {
+        List supportedModes = parameters.getSupportedFlashModes();
+        if (supportedModes != null && supportedModes.contains(mode)) {
             flashMode = mode;
             parameters.setFlashMode(flashMode);
             camera.setParameters(parameters);


### PR DESCRIPTION
`getSupportedFlashModes` returns null for front camera on most devices.