### PR TITLE
pass overlayColor to selected image [android]

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
@@ -88,7 +88,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
 
             final SelectableImage selectableImageView = (SelectableImage) this.itemView;
             selectableImageView.setUnsupportedUIParams(overlayColor, unsupportedFinalImage, unsupportedText, unsupportedTextColor);
-            selectableImageView.setDrawables(selectedDrawable, unselectedDrawable);
+            selectableImageView.setDrawables(selectedDrawable, unselectedDrawable, selectionOverlayColor);
             selectableImageView.bind(executor, selected, forceBind, image.id, isSupported);
             selectableImageView.setOnClickListener(this);
         }
@@ -162,6 +162,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
     }
 
     private String overlayColor;
+    private Integer selectionOverlayColor;
     private Drawable unsupportedFinalImage;
     private String unsupportedText;
     private String unsupportedTextColor;
@@ -220,6 +221,10 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
 
     public void setSelectedDrawableSize(int selectedDrawableSize) {
         this.selectedDrawableSize = selectedDrawableSize;
+    }
+
+    public void setSelectionOverlayColor(Integer overlayColor) {
+        this.selectionOverlayColor = overlayColor;
     }
 
     public void setSupportedFileTypes(ArrayList<String> supportedFileTypes) {

--- a/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryViewManager.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryViewManager.java
@@ -35,6 +35,7 @@ public class GalleryViewManager extends SimpleViewManager<GalleryView> {
     private final String SELECTION_POSITION_KEY = "imagePosition";
     private final String SELECTION_SIZE_KEY = "imageSizeAndroid";
     private final String SELECTION_ENABLED_KEY = "enable";
+    private final String SELECTION_OVERLAY_KEY = "overlayColor";
 
     /**
      * A handler is required in order to sync configurations made to the adapter - some must run off the UI thread (e.g. drawables
@@ -142,6 +143,7 @@ public class GalleryViewManager extends SimpleViewManager<GalleryView> {
         final Integer position = getIntSafe(selectionProps, SELECTION_POSITION_KEY);
         final String size = getStringSafe(selectionProps, SELECTION_SIZE_KEY);
         final Boolean enabled = getBooleanSafe(selectionProps, SELECTION_ENABLED_KEY);
+        final Integer selectionOverlayColor = getIntSafe(selectionProps, SELECTION_OVERLAY_KEY);
         dispatchOnConfigJobQueue(new Runnable() {
             @Override
             public void run() {
@@ -167,6 +169,7 @@ public class GalleryViewManager extends SimpleViewManager<GalleryView> {
                 }
 
                 viewAdapter.setShouldEnabledSelection(enabled != null ? enabled : true);
+                viewAdapter.setSelectionOverlayColor(selectionOverlayColor);
             }
         });
     }

--- a/android/src/main/java/com/wix/RNCameraKit/gallery/SelectableImage.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/SelectableImage.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.Drawable;
 import android.provider.MediaStore;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -33,6 +34,7 @@ public class SelectableImage extends FrameLayout {
 
     private final ImageView imageView;
     private final ImageView selectedView;
+    private final View selectedOverlay;
     private int id = -1;
     private Runnable currentLoader;
     private Drawable selectedDrawable;
@@ -40,6 +42,7 @@ public class SelectableImage extends FrameLayout {
     private LinearLayout unsupportedLayout;
     private ImageView unsupportedImage;
     private TextView unsupportedTextView;
+    private int selectedOverlayColor = Color.parseColor("#80FFFFFF");
     private boolean selected;
     private int inSampleSize;
 
@@ -49,6 +52,9 @@ public class SelectableImage extends FrameLayout {
         setBackgroundColor(0xedeff0);
         imageView = new ImageView(context);
         addView(imageView, MATCH_PARENT, MATCH_PARENT);
+
+        selectedOverlay = new View(context);
+        addView(selectedOverlay, MATCH_PARENT, MATCH_PARENT);
 
         selectedView = new ImageView(context);
         addView(selectedView, createSelectedImageParams(selectedImageGravity, selectedImageSize));
@@ -152,11 +158,13 @@ public class SelectableImage extends FrameLayout {
     public void setSelected(boolean selected) {
         this.selected = selected;
         selectedView.setImageDrawable(selected ? selectedDrawable : unselectedDrawable);
+        selectedOverlay.setBackgroundColor(selected ? this.selectedOverlayColor : Color.TRANSPARENT);
     }
 
-    public void setDrawables(Drawable selectedDrawable, Drawable unselectedDrawable) {
+    public void setDrawables(Drawable selectedDrawable, Drawable unselectedDrawable, Integer overlayColor) {
         this.selectedDrawable = selectedDrawable;
         this.unselectedDrawable = unselectedDrawable;
+        this.selectedOverlayColor = overlayColor != null ? overlayColor : Color.parseColor("#80FFFFFF");
     }
 
 

--- a/src/CameraKitGalleryView.android.js
+++ b/src/CameraKitGalleryView.android.js
@@ -73,6 +73,11 @@ export default class CameraKitGalleryView extends Component {
       _.update(transformedProps, 'selection.imagePosition', (position) => positionCode);
     }
 
+    const selectionOverlayColor = _.get(transformedProps, 'selection.overlayColor');
+    if (selectionOverlayColor) {
+      _.update(transformedProps, 'selection.overlayColor', (color) => processColor(selectionOverlayColor));
+    }
+
     return <GalleryView {...transformedProps} onTapImage={this.onTapImage}/>
   }
 


### PR DESCRIPTION
Ability to pass selection overlay color on android.
```
selection={{
              ...
              overlayColor: 'rgba(255, 0, 124, 0.5)',
            }}
```
default value is White with 0.5 alpha like in iOS.