### PR TITLE
Fix memory leak caused by using the view to post to the UI thread

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
@@ -16,6 +16,8 @@ import com.facebook.react.uimanager.UIManagerModule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -141,7 +143,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
     class CustomButtonViewHolder extends AbsViewHolder implements View.OnClickListener {
 
         CustomButtonViewHolder() {
-            super(new ImageView(GalleryAdapter.this.view.getContext()));
+            super(new ImageView(GalleryAdapter.this.reactContext.getApplicationContext()));
 
             final ImageView imageView = (ImageView) this.itemView;
             imageView.setScaleType(ImageView.ScaleType.CENTER);
@@ -178,13 +180,16 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
     private int customButtonBackgroundColor = DEFAULT_CUSTOM_BUTTON_BACKGROUND_COLOR;
     private boolean enableSelection = true;
 
+    private final GalleryView galleryView;
+    private final ReactContext reactContext;
+    private final ThreadPoolExecutor executor;
+
     private boolean isDirty = true;
     private ArrayList<Image> images = new ArrayList<>();
-    private GalleryView view;
-    private ThreadPoolExecutor executor;
 
-    public GalleryAdapter(GalleryView view) {
-        this.view = view;
+    public GalleryAdapter(ReactContext reactContext, GalleryView galleryView) {
+        this.reactContext = reactContext;
+        this.galleryView = galleryView;
         setHasStableIds(true);
         int cores = Runtime.getRuntime().availableProcessors();
         executor = new ThreadPoolExecutor(cores, cores, 1, TimeUnit.SECONDS, new LinkedBlockingDeque<Runnable>());
@@ -280,7 +285,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
             args = new String[]{albumName};
         }
 
-        Cursor cursor = view.getContext().getContentResolver().query(
+        Cursor cursor = reactContext.getApplicationContext().getContentResolver().query(
                 MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                 PROJECTION,
                 selection,
@@ -308,19 +313,19 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
     }
 
     private void notifyItemsLoaded(final int preCount, final int postCount) {
-        view.post(new Runnable() {
+        reactContext.runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
-                if (!view.isComputingLayout()) {
+                if (!galleryView.isComputingLayout()) {
                     if (preCount == 0) {
                         notifyItemRangeInserted(0, postCount);
                     } else {
-                        view.swapAdapter(GalleryAdapter.this, true);
+                        galleryView.swapAdapter(GalleryAdapter.this, true);
                     }
                     // http://stackoverflow.com/a/42549611/453052
-                    view.scrollBy(0, 0);
+                    galleryView.scrollBy(0, 0);
                 } else {
-                    view.postDelayed(new Runnable() {
+                    new Timer().schedule(new TimerTask() {
                         @Override
                         public void run() {
                             notifyItemsLoaded(preCount, postCount);
@@ -334,7 +339,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
     @Override
     public AbsViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         if (viewType == VIEW_TYPE_IMAGE) {
-            SelectableImage v = new SelectableImage(view.getContext(), selectedDrawableGravity, selectedDrawableSize);
+            SelectableImage v = new SelectableImage(reactContext, selectedDrawableGravity, selectedDrawableSize);
             v.setScaleType(ImageView.ScaleType.CENTER_CROP);
             v.setBackgroundColor(Color.LTGRAY);
             return new ImageHolder(v);
@@ -367,16 +372,14 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
     }
 
     public void onTapImage(String uri, Integer width, Integer height) {
-        final ReactContext reactContext = ((ReactContext) view.getContext());
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(new TapImageEvent(getRootViewId(), uri, width, height));
     }
 
     public void onTapCustomButton() {
-        final ReactContext reactContext = ((ReactContext) view.getContext());
         reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(new TapCustomButtonEvent(getRootViewId()));
     }
 
     private int getRootViewId() {
-        return view.getId();
+        return galleryView.getId();
     }
 }

--- a/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryViewManager.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryViewManager.java
@@ -59,7 +59,7 @@ public class GalleryViewManager extends SimpleViewManager<GalleryView> {
         adapterConfigHandler = new Handler(handlerThread.getLooper());
 
         GalleryView view = new GalleryView(reactContext);
-        view.setAdapter(new GalleryAdapter(view));
+        view.setAdapter(new GalleryAdapter(reactContext, view));
         return view;
     }
 

--- a/android/src/main/java/com/wix/RNCameraKit/gallery/SelectableImage.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/SelectableImage.java
@@ -1,7 +1,5 @@
 package com.wix.RNCameraKit.gallery;
 
-import android.app.Activity;
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -34,7 +32,9 @@ public class SelectableImage extends FrameLayout {
 
     private final ImageView imageView;
     private final ImageView selectedView;
+    private final ReactContext reactContext;
     private final View selectedOverlay;
+
     private int id = -1;
     private Runnable currentLoader;
     private Drawable selectedDrawable;
@@ -46,17 +46,19 @@ public class SelectableImage extends FrameLayout {
     private boolean selected;
     private int inSampleSize;
 
-    public SelectableImage(Context context, Integer selectedImageGravity, Integer selectedImageSize) {
-        super(context);
+    public SelectableImage(ReactContext reactContext, Integer selectedImageGravity, Integer selectedImageSize) {
+        super(reactContext.getApplicationContext());
+        this.reactContext = reactContext;
+
         setPadding(1, 1, 1, 1);
         setBackgroundColor(0xedeff0);
-        imageView = new ImageView(context);
+        imageView = new ImageView(reactContext);
         addView(imageView, MATCH_PARENT, MATCH_PARENT);
 
-        selectedOverlay = new View(context);
+        selectedOverlay = new View(reactContext);
         addView(selectedOverlay, MATCH_PARENT, MATCH_PARENT);
 
-        selectedView = new ImageView(context);
+        selectedView = new ImageView(reactContext);
         addView(selectedView, createSelectedImageParams(selectedImageGravity, selectedImageSize));
 
         createUnsupportedView();
@@ -119,7 +121,6 @@ public class SelectableImage extends FrameLayout {
             currentLoader = new Runnable() {
                 @Override
                 public void run() {
-
                     BitmapFactory.Options options = new BitmapFactory.Options();
                     if (inSampleSize == 0) {
                         inSampleSize = Utils.calculateInSampleSize(MINI_THUMB_WIDTH,MINI_THUMB_HEIGHT, getWidth(), getHeight());
@@ -133,14 +134,13 @@ public class SelectableImage extends FrameLayout {
                             options);
 
                     if (SelectableImage.this.id == id) {
-                        ((Activity) ((ReactContext) getContext()).getBaseContext()).runOnUiThread(new Runnable() {
+                        reactContext.runOnUiQueueThread(new Runnable() {
                             @Override
                             public void run() {
                                 imageView.setImageBitmap(bmp);
                             }
                         });
                     }
-
                 }
             };
             executor.execute(currentLoader);


### PR DESCRIPTION
Test device was a Nexus 5 with Android 6.0.1 and React Native 0.39.2. Before this change, we were leaking ~11 MB every time we unmounted the gallery view.

### Before
![before](https://user-images.githubusercontent.com/1542454/28448093-3ff86ce8-6d8a-11e7-9702-620d46214765.gif)

### After
![after](https://user-images.githubusercontent.com/1542454/28448159-8120c62a-6d8a-11e7-95ba-84ba3f032fa0.gif)

Using LeakCanary:
```
* com.wix.RNCameraKit.gallery.GalleryView has leaked:
* GC ROOT android.os.HandlerThread.localValues
* references java.lang.ThreadLocal$Values.table
* references array java.lang.Object[].[3]
* references android.view.ViewRootImpl$RunQueue.mActions
* references java.util.ArrayList.array
* references array java.lang.Object[].[0]
* references android.view.ViewRootImpl$RunQueue$HandlerAction.action
* references com.wix.RNCameraKit.gallery.GalleryAdapter$1.this$0 (anonymous implementation of java.lang.Runnable)
* references com.wix.RNCameraKit.gallery.GalleryAdapter.mObservable
* references android.support.v7.widget.RecyclerView$AdapterDataObservable.mObservers
* references java.util.ArrayList.array
* references array java.lang.Object[].[0]
* references android.support.v7.widget.RecyclerView$RecyclerViewDataObserver.this$0
* leaks com.wix.RNCameraKit.gallery.GalleryView instance
```