### PR TITLE
Pull in prop-types dependency to avoid deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {},
   "dependencies": {
-    "lodash": "^4.14.2"
+    "lodash": "^4.14.2",
+    "prop-types": "^15.5.10"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {
   StyleSheet,
   Text,


### PR DESCRIPTION
PropTypes have been extracted from React core as of version 16 (alpha). This pull eliminates the deprecation warnings emitted by newer versions of react-native due to this.