### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/RNCameraKitPackage.java
+++ b/android/src/main/java/com/wix/RNCameraKit/RNCameraKitPackage.java
@@ -51,7 +51,7 @@ public class RNCameraKitPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fix for a breaking change in React Native 47. createJSModules function is now deprecated and the @override breaks it. Probably remove the whole function