### PR TITLE
images in gallery should be at the correct orientation on android

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
@@ -45,7 +45,8 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
             MediaStore.Images.Media._ID,
             MediaStore.Images.Media.MIME_TYPE,
             MediaStore.Images.Media.WIDTH,
-            MediaStore.Images.Media.HEIGHT
+            MediaStore.Images.Media.HEIGHT,
+            MediaStore.Images.Media.ORIENTATION
     };
 
     private class Image {
@@ -54,13 +55,15 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
         String mimeType;
         Integer width;
         Integer height;
+        Integer orientation;
 
-        public Image(String uri, Integer id, String mimeType, Integer width, Integer height) {
+        public Image(String uri, Integer id, String mimeType, Integer width, Integer height,Integer orientation) {
             this.uri = uri;
             this.id = id;
             this.mimeType = mimeType;
             this.width = width;
             this.height = height;
+            this.orientation = orientation;
         }
     }
 
@@ -91,7 +94,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
             final SelectableImage selectableImageView = (SelectableImage) this.itemView;
             selectableImageView.setUnsupportedUIParams(overlayColor, unsupportedFinalImage, unsupportedText, unsupportedTextColor);
             selectableImageView.setDrawables(selectedDrawable, unselectedDrawable, selectionOverlayColor);
-            selectableImageView.bind(executor, selected, forceBind, image.id, isSupported);
+            selectableImageView.bind(executor, selected, forceBind, image.id, isSupported,image.orientation);
             selectableImageView.setOnClickListener(this);
         }
 
@@ -299,13 +302,15 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
             int mimeIndex = cursor.getColumnIndex(MediaStore.Images.Media.MIME_TYPE);
             int widthIndex = cursor.getColumnIndex(MediaStore.Images.Media.WIDTH);
             int heightIndex = cursor.getColumnIndex(MediaStore.Images.Media.HEIGHT);
+            int orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION);
             do {
-                images.add(new Image(cursor.getString(dataIndex), cursor.getInt(idIndex), cursor.getString(mimeIndex), cursor.getInt(widthIndex), cursor.getInt(heightIndex)));
+                images.add(new Image(cursor.getString(dataIndex), cursor.getInt(idIndex), cursor.getString(mimeIndex),
+                        cursor.getInt(widthIndex), cursor.getInt(heightIndex), cursor.getInt(orientationIndex)));
             } while (cursor.moveToNext());
         }
 
         if (shouldShowCustomButton()) {
-            images.add(new Image(null, -1, "", 0, 0));
+            images.add(new Image(null, -1, "", 0, 0,0));
         }
         Collections.reverse(images);
         cursor.close();

--- a/android/src/main/java/com/wix/RNCameraKit/gallery/SelectableImage.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/SelectableImage.java
@@ -3,6 +3,7 @@ package com.wix.RNCameraKit.gallery;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.graphics.Matrix;
 import android.graphics.drawable.Drawable;
 import android.provider.MediaStore;
 import android.util.TypedValue;
@@ -107,7 +108,7 @@ public class SelectableImage extends FrameLayout {
         imageView.setScaleType(scaleType);
     }
 
-    public void bind(ThreadPoolExecutor executor, boolean selected, boolean forceBind, final Integer id, boolean supported) {
+    public void bind(ThreadPoolExecutor executor, boolean selected, boolean forceBind, final Integer id, boolean supported,final Integer orientation) {
         this.selected = selected;
         selectedView.setImageDrawable(selected ? selectedDrawable : unselectedDrawable);
         if (this.id != id || forceBind) {
@@ -119,6 +120,15 @@ public class SelectableImage extends FrameLayout {
             }
 
             currentLoader = new Runnable() {
+
+                public Bitmap orient(final Bitmap bmp,final Integer orientation){
+                    if (orientation != 0) {
+                        Matrix matrix = new Matrix();
+                        matrix.postRotate(orientation);
+                        return Bitmap.createBitmap(bmp, 0, 0, bmp.getWidth(), bmp.getHeight(), matrix, true);
+                    }
+                    return bmp;
+                }
                 @Override
                 public void run() {
                     BitmapFactory.Options options = new BitmapFactory.Options();
@@ -127,11 +137,11 @@ public class SelectableImage extends FrameLayout {
                     }
                     options.inSampleSize = inSampleSize;
 
-                    final Bitmap bmp = MediaStore.Images.Thumbnails.getThumbnail(
+                    final Bitmap bmp = orient(MediaStore.Images.Thumbnails.getThumbnail(
                             getContext().getContentResolver(),
                             id,
                             MediaStore.Images.Thumbnails.MINI_KIND,
-                            options);
+                            options), orientation);
 
                     if (SelectableImage.this.id == id) {
                         reactContext.runOnUiQueueThread(new Runnable() {


### PR DESCRIPTION
On android the gallery shows images take in portrait mode rotated on the side. This change orients images with orientation metadata so they'll look upright.

I assume that the default behavior should be to orient the images, but if not, a flag can be added.

I tested it on my own project. However I wasn't able to run the example (I'm on windows, and for me react-native run-android doesn't work in the example folder)