### PR TITLE
fixed crash when disallowing access to photos then trying again

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKGalleryViewManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKGalleryViewManager.m
@@ -498,7 +498,9 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-    self.galleryView = [[CKGalleryView alloc] init];
+    if (self.galleryView == nil) {
+        self.galleryView = [[CKGalleryView alloc] init];
+    }
     return self.galleryView;
 }
 


### PR DESCRIPTION
app would crash when denying access to photos and then trying to view the gallery again