### PR TITLE
Added the backgroundColor property to the CameraView on Android

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/camera/CameraView.java
+++ b/android/src/main/java/com/wix/RNCameraKit/camera/CameraView.java
@@ -26,6 +26,7 @@ public class CameraView extends FrameLayout implements SurfaceHolder.Callback {
     private IViewFinder viewFinder;
     @ColorInt private int frameColor = Color.GREEN;
     @ColorInt private int laserColor = Color.RED;
+    @ColorInt private int backgroundColor = Color.BLACK;
 
     public CameraView(ThemedReactContext context) {
         super(context);
@@ -34,6 +35,7 @@ public class CameraView extends FrameLayout implements SurfaceHolder.Callback {
 
         surface = new SurfaceView(context);
         setBackgroundColor(Color.BLACK);
+        surface.setBackgroundColor(backgroundColor);
         addView(surface, MATCH_PARENT, MATCH_PARENT);
         surface.getHolder().addCallback(this);
         surface.setOnClickListener(new OnClickListener() {
@@ -149,6 +151,13 @@ public class CameraView extends FrameLayout implements SurfaceHolder.Callback {
             }
         }
         return viewFrameRect;
+    }
+
+    public void setCameraBgColor(@ColorInt int color) {
+        this.backgroundColor = color;
+        if (surface != null) {
+            surface.setBackgroundColor(backgroundColor);
+        }
     }
 
     public void setFrameColor(@ColorInt int color) {

--- a/android/src/main/java/com/wix/RNCameraKit/camera/CameraViewManager.java
+++ b/android/src/main/java/com/wix/RNCameraKit/camera/CameraViewManager.java
@@ -309,6 +309,11 @@ public class CameraViewManager extends SimpleViewManager<CameraView> {
         }
     }
 
+    @ReactProp(name = "backgroundColor", defaultInt = Color.BLACK)
+    public void setCameraBgColor(CameraView view, @ColorInt int color) {
+        view.setCameraBgColor(color);
+    }
+
     @ReactProp(name = "frameColor", defaultInt = Color.GREEN)
     public void setFrameColor(CameraView view, @ColorInt int color) {
         view.setFrameColor(color);

--- a/src/CameraKitCamera.android.js
+++ b/src/CameraKitCamera.android.js
@@ -14,6 +14,7 @@ export default class CameraKitCamera extends React.Component {
   render() {
     const transformedProps = _.cloneDeep(this.props);
     _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
+    _.update(transformedProps, 'backgroundColor', (c) => processColor(c));
     _.update(transformedProps, 'frameColor', (c) => processColor(c));
     _.update(transformedProps, 'laserColor', (c) => processColor(c));
 


### PR DESCRIPTION
When using a modal, the `<CameraKitCamera/>` was showing the screen behind while loading up camera and when the device did not support a camera (tested on Genymotion).

This PR enables the usage of `<CameraKitCamera backgroundColor="green" ...\>` to show a color instead of the transparency. By default, the backgroundColor is "black"