### PR TITLE
[ios] Handle initial orientation

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -175,6 +175,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         self.previewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
         [self.layer addSublayer:self.previewLayer];
         self.previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+        self.previewLayer.orientation = [[UIApplication sharedApplication] statusBarOrientation];
 #endif
         
         UIView *focusView = [[UIView alloc] initWithFrame:CGRectZero];


### PR DESCRIPTION
This doesn't handle orientation changes. But at least make sure the orientation is correct when the view is first created. (#4 #65)