### PR TITLE
Fixes “Undefined is not an object (evaluating '_reactNative.Image.res…

### DIFF
--- a/old-example/src/GalleryScreen.ios.js
+++ b/old-example/src/GalleryScreen.ios.js
@@ -44,7 +44,7 @@ export default class GalleryScreen extends Component {
       <View style={{position: 'absolute', width, height, backgroundColor: 'green'}}>
         <View style={styles.container}>
           <Image
-            resizeMode={Image.resizeMode.cover}
+            resizeMode={"cover"}
             style={{width: 300, height: 300}}
             source={{uri: this.state.presentedImage.imageUri}}
           />

--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -119,7 +119,7 @@ export default class CameraScreenBase extends Component {
         <Image
           style={{ flex: 1, justifyContent: 'center' }}
           source={this.state.flashData.image}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode={"contain"}
         />
       </TouchableOpacity>
   }
@@ -130,7 +130,7 @@ export default class CameraScreenBase extends Component {
         <Image
           style={{ flex: 1, justifyContent: 'center' }}
           source={this.props.cameraFlipImage}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode={"contain"}
         />
       </TouchableOpacity>
   }


### PR DESCRIPTION
Fixes “Undefined is not an object (evaluating '_reactNative.Image.resizeMode.contain’)” issue introduced into CameraKitCameraScreenBase with React Native 0.56

https://github.com/facebook/react-native/commit/870775ee738e9405c6545500f9a637df9b513a02