### PR TITLE
Configuration 'compile' in project is deprecated. Use 'implementation…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,8 +19,8 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
-    compile 'com.google.zxing:core:3.3.0'
-    compile group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.9.1'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.android.support:recyclerview-v7:25.0.1'
+    implementation 'com.google.zxing:core:3.3.0'
+    implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.9.1'
 }


### PR DESCRIPTION
…' instead

fixes #186

More info on implementation
https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations