### PR TITLE
Declare variable when exporting CameraKitCameraScreen styleObject

### DIFF
--- a/src/CameraScreen/CameraKitCameraScreenStyleObject.android.js
+++ b/src/CameraScreen/CameraKitCameraScreenStyleObject.android.js
@@ -1,7 +1,7 @@
 import { Dimensions } from 'react-native';
 const { width, height } = Dimensions.get('window');
 
-export default styleObject = {
+const styleObject = {
     cameraContainer: {
         position: 'absolute',
         top: 0,
@@ -26,3 +26,5 @@ export default styleObject = {
         flexDirection: 'column'
     },
 };
+
+export default styleObject;

--- a/src/CameraScreen/CameraKitCameraScreenStyleObject.ios.js
+++ b/src/CameraScreen/CameraKitCameraScreenStyleObject.ios.js
@@ -1,4 +1,4 @@
-export default styleObject = {
+const styleObject = {
   bottomButtons: {
     flex: 2,
     flexDirection: 'row',
@@ -12,4 +12,6 @@ export default styleObject = {
 //     alignItems: 'center',
 //     padding: 10
 //   }
-}
+};
+
+export default styleObject;


### PR DESCRIPTION
Typescript linters complain of `ReferenceError: styleObject is not defined`

<img width="1019" alt="screen shot 2019-02-04 at 12 02 21 pm" src="https://user-images.githubusercontent.com/8092859/52234133-c8ffc200-2875-11e9-9244-94d00884de00.png">

Please let me know if I can supply more information.