### PR TITLE
minimum compileSdkVersion fix (Android)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
Project won't compile on recent SDK due to missing android:attr/colorError. Minimum SDK for those attributes to work are 26