### PR TITLE
Guard against null media cursor (#1)

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/GalleryAdapter.java
@@ -296,7 +296,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
                 null
         );
 
-        if (cursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             int dataIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA);
             int idIndex = cursor.getColumnIndex(MediaStore.Images.Media._ID);
             int mimeIndex = cursor.getColumnIndex(MediaStore.Images.Media.MIME_TYPE);
@@ -313,7 +313,9 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.AbsViewH
             images.add(new Image(null, -1, "", 0, 0,0));
         }
         Collections.reverse(images);
-        cursor.close();
+        if (cursor != null) {
+          cursor.close();
+        }
         notifyItemsLoaded(preItemsCount, getItemCount());
     }
 


### PR DESCRIPTION
Check to make sure the image database cursor is not null before accessing.