### PR TITLE
Fix CameraKitGallery to return valid imageuri

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKGalleryViewManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKGalleryViewManager.m
@@ -863,7 +863,7 @@ RCT_EXPORT_METHOD(modifyGalleryViewContentOffset:(NSDictionary*)params) {
         NSString *fileName = ((NSURL*)info[@"PHImageFileURLKey"]).lastPathComponent;
 
         if (!fileName) {
-            *fileName = ((NSURL*)info[@"PHImageFileUTIKey"]).lastPathComponent;
+            fileName = ((NSURL*)info[@"PHImageFileUTIKey"]).lastPathComponent;
         }
 
         fileName = [CKGalleryViewManager handleNonJPEGOrPNGFormatsFileName:fileName dataUTI:dataUTI];
@@ -875,8 +875,8 @@ RCT_EXPORT_METHOD(modifyGalleryViewContentOffset:(NSDictionary*)params) {
         
         NSURL *fileURLKey = info[@"PHImageFileURLKey"];
 
-        if (fileURLKey) {
-            !fNSURL *fileURLKey = info[@"PHImageFileUTIKey"];
+        if (!fileURLKey) {
+            fileURLKey = info[@"PHImageFileUTIKey"];
         }
         
         if (fileURLKey) {

--- a/ios/lib/ReactNativeCameraKit/CKGalleryViewManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKGalleryViewManager.m
@@ -861,6 +861,11 @@ RCT_EXPORT_METHOD(modifyGalleryViewContentOffset:(NSDictionary*)params) {
     [[PHCachingImageManager defaultManager] requestImageDataForAsset:asset options:imageRequestOptions resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
         
         NSString *fileName = ((NSURL*)info[@"PHImageFileURLKey"]).lastPathComponent;
+
+        if (!fileName) {
+            *fileName = ((NSURL*)info[@"PHImageFileUTIKey"]).lastPathComponent;
+        }
+
         fileName = [CKGalleryViewManager handleNonJPEGOrPNGFormatsFileName:fileName dataUTI:dataUTI];
         imageData = [CKGalleryViewManager handleNonJPEGOrPNGFormatsData:imageData dataUTI:dataUTI];
         
@@ -869,6 +874,10 @@ RCT_EXPORT_METHOD(modifyGalleryViewContentOffset:(NSDictionary*)params) {
         UIImage *compressedImage = [UIImage imageWithData:imageData];
         
         NSURL *fileURLKey = info[@"PHImageFileURLKey"];
+
+        if (fileURLKey) {
+            !fNSURL *fileURLKey = info[@"PHImageFileUTIKey"];
+        }
         
         if (fileURLKey) {
             


### PR DESCRIPTION
- If PHImageFileURLKey does not exist, use PHImageFileUTIKey instead

Fixes #277 