### PR TITLE
fix android crash on take picture cause conflict react-native-camera

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/camera/CameraModule.java
+++ b/android/src/main/java/com/wix/RNCameraKit/camera/CameraModule.java
@@ -51,7 +51,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
 
     @Override
     public String getName() {
-        return "CameraModule";
+        return "RNKitCameraModule";
     }
 
     @ReactMethod

--- a/src/CameraKitCamera.android.js
+++ b/src/CameraKitCamera.android.js
@@ -7,7 +7,7 @@ import {
 } from 'react-native';
 
 const NativeCamera = requireNativeComponent('CameraView', null);
-const NativeCameraModule = NativeModules.CameraModule;
+const NativeCameraModule = NativeModules.RNKitCameraModule;
 const TORCH_MODE_ON = 'on';
 const TORCH_MODE_CALL_ARG = 'torch';
 


### PR DESCRIPTION
Camera module by react-native-camera-kit is overwrited by react-native-camera cause crash on capture