### PR TITLE
Added support for Data Matrix codes (iOS only)

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -1118,7 +1118,7 @@ didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
     NSArray *supportedBarcodeTypes = @[AVMetadataObjectTypeUPCECode,AVMetadataObjectTypeCode39Code,AVMetadataObjectTypeCode39Mod43Code,
                                        AVMetadataObjectTypeEAN13Code,AVMetadataObjectTypeEAN8Code, AVMetadataObjectTypeCode93Code,
                                        AVMetadataObjectTypeCode128Code, AVMetadataObjectTypePDF417Code, AVMetadataObjectTypeQRCode,
-                                       AVMetadataObjectTypeAztecCode];
+                                       AVMetadataObjectTypeAztecCode, AVMetadataObjectTypeDataMatrixCode];
     for (NSString* object in supportedBarcodeTypes) {
         if ([currentType isEqualToString:object]) {
             result = YES;


### PR DESCRIPTION
This adds support for Data Matrix QR codes, example `Hello World` code attached here:
![image](https://user-images.githubusercontent.com/895369/84583547-634b1080-adae-11ea-8b12-00057a30a83a.png)
