### PR TITLE
Support building with iOS 9 target

### DIFF
--- a/ReactNativeCameraKit.podspec
+++ b/ReactNativeCameraKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = "Wix"
   s.homepage     = "https://github.com/wix/react-native-camera-kit"
-  s.platform     = :ios, "10.0"
+  s.platform     = :ios, "9.0"
 
   s.source       = { :git => "https://github.com/wix/react-native-camera-kit.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/lib/**/*.{h,m}"


### PR DESCRIPTION
This gets rid of the `pod install` version incompatibility error that otherwise requires devs to make this change to their `ios/Podfile`:
```
platform :ios, '10.0'
```

It should not affect functionality.