### PR TITLE
added condition for fix the issue: "Cant find variable: styleObject"

### DIFF
--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -324,7 +324,11 @@ export default class CameraScreenBase extends Component {
   }
 }
 
-import styleObject from './CameraKitCameraScreenStyleObject';
+import styleObjectAndroid from './CameraKitCameraScreenStyleObject.android';
+import styleObjectIOS from './CameraKitCameraScreenStyleObject.ios';
+
+const styleObject = IsIOS ? styleObjectIOS : styleObjectAndroid;
+
 const styles = StyleSheet.create(_.merge(styleObject, {
   textStyle: {
     color: 'white',


### PR DESCRIPTION
When I tried to run, I got this error:  "Cant find variable: styleObject". It because importing not existing file. Files are specialized for Android and iOS. There is no file existing as a baseStyle.