### PR TITLE
Added resetFocusTimeout and resetFocusWhenMotionDetected

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ And in the package list in the same file (e.g. `getPackages`) add:
 
 ```js
 import { CameraKitCamera } from 'react-native-camera-kit';
-
+```
+```jsx
 <CameraKitCamera
   ref={cam => this.camera = cam}
   style={{
@@ -75,26 +76,35 @@ import { CameraKitCamera } from 'react-native-camera-kit';
     backgroundColor: 'white'
   }}
   cameraOptions={{
-    flashMode: 'auto',             // on/off/auto(default)
-    focusMode: 'on',               // off/on(default)
-    zoomMode: 'on',                // off/on(default)
-    ratioOverlay:'1:1',            // optional, ratio overlay on the camera and crop the image seamlessly
-    ratioOverlayColor: '#00000077' // optional
+    flashMode: 'auto',                // on/off/auto(default)
+    focusMode: 'on',                  // off/on(default)
+    zoomMode: 'on',                   // off/on(default)
+    ratioOverlay:'1:1',               // optional
+    ratioOverlayColor: '#00000077'    // optional
   }}
-  onReadCode={(event) => console.log(event.nativeEvent.codeStringValue)} // optional
-  
+  onReadCode={event =>                // optional
+    console.log(event.nativeEvent.codeStringValue)
+  }
+  resetFocusTimeout={0}               // optional
+  resetFocusWhenMotionDetected={true} // optional
 />
 ```
 
-### CameraKitCamera cameraOptions
+Prop | Type | Description
+-------- | ----- | ------------
+`resetFocusTimeout`          | Number  | iOS only. Dismiss tap to focus after this many milliseconds. Default `0` (disabled). Example: `5000` is 5 seconds.
+`resetFocusWhenMotionDetected` | Boolean | iOS only. Dismiss tap to focus when focus area content changes. Native iOS feature, see documentation: https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624644-subjectareachangemonitoringenabl?language=objc). Default `true`.
+`cameraOptions`                      | Object  | See `cameraOptions` below
+
+### cameraOptions
 
 Attribute         | Values                 | Description
 ----------------- | ---------------------- | -----------
-`flashMode`         |`'on'`/`'off'`/`'auto'` | camera flash mode (default is `auto`)
-`focusMode`         | `'on'`/`'off'`         | camera focus mode (default is `on`)
-`zoomMode`          | `'on'`/`'off'`         | camera zoom mode
-`ratioOverlay`      | `['int':'int', ...]`   | overlay on top of the camera view (crop the image to the selected size) Example: `['16:9', '1:1', '3:4']`
-`ratioOverlayColor` |  Color                 | any color with alpha (default is ```'#ffffff77'```)
+`flashMode`         |`'on'`/`'off'`/`'auto'` | Camera flash mode (default is `auto`)
+`focusMode`         | `'on'`/`'off'`         | Camera focus mode (default is `on`)
+`zoomMode`          | `'on'`/`'off'`         | Camera zoom mode
+`ratioOverlay`      | `['int':'int', ...]`   | Crop the image to the selected ratio. Example: `['16:9', '1:1', '3:4']`
+`ratioOverlayColor` |  Color                 | Any color with alpha (default is ```'#ffffff77'```)
 
 ### CameraKitCamera API
 

--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -77,7 +77,6 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 #define CAMERA_OPTION_CAMERA_RATIO_OVERLAY          @"ratioOverlay"
 #define CAMERA_OPTION_CAMERA_RATIO_OVERLAY_COLOR    @"ratioOverlayColor"
 #define CAMERA_OPTION_ON_READ_QR_CODE               @"onReadQRCode"
-#define TIMER_FOCUS_TIME_SECONDS            5
 
 @interface CKCamera () <AVCaptureMetadataOutputObjectsDelegate>
 
@@ -87,6 +86,12 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 @property (nonatomic, strong) UIView *focusView;
 @property (nonatomic, strong) NSTimer *focusViewTimer;
 @property (nonatomic, strong) CKCameraOverlayView *cameraOverlayView;
+
+@property (nonatomic, strong) NSTimer *focusResetTimer;
+@property (nonatomic) BOOL startFocusResetTimerAfterFocusing;
+@property (nonatomic) NSInteger resetFocusTimeout;
+@property (nonatomic) BOOL resetFocusWhenMotionDetected;
+@property (nonatomic) BOOL tapToFocusEngaged;
 
 // session management
 @property (nonatomic) dispatch_queue_t sessionQueue;
@@ -184,7 +189,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         [self handleCameraPermission];
         
 #if !(TARGET_IPHONE_SIMULATOR)
-        [self setupCaptionSession];
+        [self setupCaptureSession];
         self.previewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
         [self.layer addSublayer:self.previewLayer];
         self.previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
@@ -258,7 +263,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
     //    }
 }
 
--(void)setupCaptionSession {
+-(void)setupCaptureSession {
     // Setup the capture session.
     // In general it is not safe to mutate an AVCaptureSession or any of its inputs, outputs, or connections from multiple threads at the same time.
     // Why not do all of this on the main queue?
@@ -432,34 +437,6 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 #pragma mark -
 
 
--(void)startFocusViewTimer {
-    [self stopFocusViewTimer];
-    
-    self.focusViewTimer = [NSTimer scheduledTimerWithTimeInterval:TIMER_FOCUS_TIME_SECONDS target:self selector:@selector(dismissFocusView) userInfo:nil repeats:NO];
-}
-
--(void)stopFocusViewTimer {
-    if (self.focusViewTimer) {
-        [self.focusViewTimer invalidate];
-        self.focusViewTimer = nil;
-    }
-}
-
--(void)dismissFocusView {
-    
-    [self stopFocusViewTimer];
-    
-    [UIView animateWithDuration:0.8 animations:^{
-        self.focusView.alpha = 0;
-        
-    } completion:^(BOOL finished) {
-        self.focusView.frame = CGRectZero;
-        self.focusView.hidden = YES;
-        self.focusView.alpha = 1;
-    }];
-}
-
-
 + (AVCaptureDevice *)deviceWithMediaType:(NSString *)mediaType preferringPosition:(AVCaptureDevicePosition)position
 {
     NSArray *devices = [AVCaptureDevice devicesWithMediaType:mediaType];
@@ -529,22 +506,9 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
     dispatch_async( self.sessionQueue, ^{
         AVCaptureConnection *connection = [self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
         
-        // Use device orientation to support taking landscape photos with orientation lock (portrait)
-        switch([UIDevice currentDevice].orientation) {
-            default:
-            case UIDeviceOrientationPortrait:
-                connection.videoOrientation = AVCaptureVideoOrientationPortrait;
-                break;
-            case UIDeviceOrientationPortraitUpsideDown:
-                connection.videoOrientation = AVCaptureVideoOrientationPortraitUpsideDown;
-                break;
-            case UIDeviceOrientationLandscapeLeft:
-                connection.videoOrientation = AVCaptureVideoOrientationLandscapeRight;
-                break;
-            case UIDeviceOrientationLandscapeRight:
-                connection.videoOrientation = AVCaptureVideoOrientationLandscapeLeft;
-                break;
-        }
+        // Update the orientation on the still image output video connection before capturing.
+        connection.videoOrientation = self.previewLayer.connection.videoOrientation;
+        
         
         // Capture a still image.
         [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler:^( CMSampleBufferRef imageDataSampleBuffer, NSError *error ) {
@@ -606,6 +570,8 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
                     block(imageInfoDict);
                 }
                 CGImageRelease(imageRef);
+                
+                [self resetFocus];
             } else {
                 //NSLog( @"Could not capture still image: %@", error );
             }
@@ -656,6 +622,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         AVCaptureDevice *videoDevice = [CKCamera deviceWithMediaType:AVMediaTypeVideo preferringPosition:preferredPosition];
         AVCaptureDeviceInput *videoDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:nil];
         
+        [self removeObservers];
         [self.session beginConfiguration];
         
         // Remove the existing device input first, since using the front and back camera simultaneously is not supported.
@@ -665,7 +632,6 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
             [[NSNotificationCenter defaultCenter] removeObserver:self name:AVCaptureDeviceSubjectAreaDidChangeNotification object:currentVideoDevice];
             
             [CKCamera setFlashMode:self.flashMode forDevice:videoDevice];
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(subjectAreaDidChange:) name:AVCaptureDeviceSubjectAreaDidChangeNotification object:videoDevice];
             
             [self.session addInput:videoDeviceInput];
             self.videoDeviceInput = videoDeviceInput;
@@ -680,6 +646,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         }
         
         [self.session commitConfiguration];
+        [self addObservers];
         
         dispatch_async( dispatch_get_main_queue(), ^{
             
@@ -718,63 +685,124 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 
 - (void)focusAndExposeTap:(UIGestureRecognizer *)gestureRecognizer
 {
-    CGPoint devicePoint = [(AVCaptureVideoPreviewLayer *)self.previewLayer captureDevicePointOfInterestForPoint:[gestureRecognizer locationInView:gestureRecognizer.view]];
+    CGPoint touchPoint = [gestureRecognizer locationInView:self];
+    CGPoint devicePoint = [(AVCaptureVideoPreviewLayer *)self.previewLayer captureDevicePointOfInterestForPoint:touchPoint];
+    
+    // Engage manual focus
     [self focusWithMode:AVCaptureFocusModeAutoFocus exposeWithMode:AVCaptureExposureModeAutoExpose atDevicePoint:devicePoint monitorSubjectAreaChange:YES];
     
-    CGPoint touchPoint = [gestureRecognizer locationInView:self];
-    CGFloat halfDiagonal = 80;
+    // Disengage manual focus once focusing finishing (if focusTimeout > 0)
+    // See [self observeValueForKeyPath]
+    self.startFocusResetTimerAfterFocusing = YES;
+    
+    self.tapToFocusEngaged = YES;
+
+    // Animate focus rectangle
+    CGFloat halfDiagonal = 73;
     CGFloat halfDiagonalAnimation = halfDiagonal*2;
     
-    CGRect focusViewFrame = CGRectMake(touchPoint.x - (halfDiagonal/2), touchPoint.y - (halfDiagonal/2), halfDiagonal, halfDiagonal);
-    CGRect focusViewFrameFoAnimation = CGRectMake(touchPoint.x - (halfDiagonalAnimation/2), touchPoint.y - (halfDiagonalAnimation/2), halfDiagonalAnimation, halfDiagonalAnimation);
+    CGRect focusViewFrame = CGRectMake(touchPoint.x - (halfDiagonal/2),
+                                       touchPoint.y - (halfDiagonal/2),
+                                       halfDiagonal,
+                                       halfDiagonal);
+    
+    self.focusView.alpha = 0;
+    self.focusView.hidden = NO;
+    self.focusView.frame = CGRectMake(touchPoint.x - (halfDiagonalAnimation/2),
+                                      touchPoint.y - (halfDiagonalAnimation/2),
+                                      halfDiagonalAnimation,
+                                      halfDiagonalAnimation);
+    
+    [UIView animateWithDuration:0.2 animations:^{
+        self.focusView.frame = focusViewFrame;
+        self.focusView.alpha = 1;
+    } completion:^(BOOL finished) {
+        self.focusView.alpha = 1;
+        self.focusView.frame = focusViewFrame;
+    }];
+}
+
+- (void)resetFocus
+{
+    if (self.focusResetTimer) {
+        [self.focusResetTimer invalidate];
+        self.focusResetTimer = nil;
+    }
+    
+    // Resetting focus to continuous focus, so not interested in resetting anymore
+    self.startFocusResetTimerAfterFocusing = NO;
+
+    // Avoid showing reset-focus animation after each photo capture
+    if (!self.tapToFocusEngaged) {
+        return;
+    }
+    
+    self.tapToFocusEngaged = NO;
+    
+    // 1. Reset actual camera focus
+    CGPoint deviceCenter = CGPointMake(0.5, 0.5);
+    [self focusWithMode:AVCaptureFocusModeContinuousAutoFocus exposeWithMode:AVCaptureExposureModeContinuousAutoExposure atDevicePoint:deviceCenter monitorSubjectAreaChange:NO];
+    
+    // 2. Create animation to indicate the new focus location
+    CGPoint layerCenter = [self.previewLayer pointForCaptureDevicePointOfInterest:deviceCenter];
+    
+    CGFloat halfDiagonal = 123;
+    CGFloat halfDiagonalAnimation = halfDiagonal*2;
+    
+    CGRect focusViewFrame = CGRectMake(layerCenter.x - (halfDiagonal/2), layerCenter.y - (halfDiagonal/2), halfDiagonal, halfDiagonal);
+    CGRect focusViewFrameFoAnimation = CGRectMake(layerCenter.x - (halfDiagonalAnimation/2), layerCenter.y - (halfDiagonalAnimation/2), halfDiagonalAnimation, halfDiagonalAnimation);
     
     self.focusView.alpha = 0;
     self.focusView.hidden = NO;
     self.focusView.frame = focusViewFrameFoAnimation;
     
-    
     [UIView animateWithDuration:0.2 animations:^{
         self.focusView.frame = focusViewFrame;
         self.focusView.alpha = 1;
-        
     } completion:^(BOOL finished) {
         self.focusView.alpha = 1;
         self.focusView.frame = focusViewFrame;
         
+        if (self.focusViewTimer) {
+            [self.focusViewTimer invalidate];
+        }
+        self.focusViewTimer = [NSTimer scheduledTimerWithTimeInterval:2 repeats:NO block:^(NSTimer *timer) {
+            [UIView animateWithDuration:0.2 animations:^{
+                self.focusView.alpha = 0;
+            } completion:^(BOOL finished) {
+                self.focusView.frame = CGRectZero;
+                self.focusView.hidden = YES;
+            }];
+        }];
     }];
-    
-    [self startFocusViewTimer];
 }
-
 
 - (void)focusWithMode:(AVCaptureFocusMode)focusMode exposeWithMode:(AVCaptureExposureMode)exposureMode atDevicePoint:(CGPoint)point monitorSubjectAreaChange:(BOOL)monitorSubjectAreaChange
 {
     dispatch_async( self.sessionQueue, ^{
         AVCaptureDevice *device = self.videoDeviceInput.device;
         NSError *error = nil;
-        if ( [device lockForConfiguration:&error] ) {
-            // Setting (focus/exposure)PointOfInterest alone does not initiate a (focus/exposure) operation.
-            // Call -set(Focus/Exposure)Mode: to apply the new point of interest.
-            if ( device.isFocusPointOfInterestSupported && [device isFocusModeSupported:focusMode] ) {
-                device.focusPointOfInterest = point;
-                device.focusMode = focusMode;
-            }
-            
-            if ( device.isExposurePointOfInterestSupported && [device isExposureModeSupported:exposureMode] ) {
-                device.exposurePointOfInterest = point;
-                device.exposureMode = exposureMode;
-            }
-            
-            device.subjectAreaChangeMonitoringEnabled = monitorSubjectAreaChange;
-            [device unlockForConfiguration];
+        if (![device lockForConfiguration:&error]) {
+            NSLog(@"Unable to device.lockForConfiguration() %@", error);
+            return;
         }
-        else {
-            //NSLog( @"Could not lock device for configuration: %@", error );
+        
+        // Setting (focus/exposure)PointOfInterest alone does not initiate a (focus/exposure) operation.
+        // Call -set(Focus/Exposure)Mode: to apply the new point of interest.
+        if ( device.isFocusPointOfInterestSupported && [device isFocusModeSupported:focusMode] ) {
+            device.focusPointOfInterest = point;
+            device.focusMode = focusMode;
         }
-    } );
+        
+        if ( device.isExposurePointOfInterestSupported && [device isExposureModeSupported:exposureMode] ) {
+            device.exposurePointOfInterest = point;
+            device.exposureMode = exposureMode;
+        }
+        
+        device.subjectAreaChangeMonitoringEnabled = monitorSubjectAreaChange && self.resetFocusWhenMotionDetected;
+        [device unlockForConfiguration];
+    });
 }
-
-
 
 - (void)zoom:(CGFloat)velocity {
     if (isnan(velocity)) {
@@ -998,6 +1026,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         [self.session addObserver:self forKeyPath:@"running" options:NSKeyValueObservingOptionNew context:SessionRunningContext];
         [self.stillImageOutput addObserver:self forKeyPath:@"capturingStillImage" options:NSKeyValueObservingOptionNew context:CapturingStillImageContext];
         
+        [self.videoDeviceInput.device addObserver:self forKeyPath:@"adjustingFocus" options:NSKeyValueObservingOptionNew context:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(subjectAreaDidChange:) name:AVCaptureDeviceSubjectAreaDidChangeNotification object:self.videoDeviceInput.device];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionRuntimeError:) name:AVCaptureSessionRuntimeErrorNotification object:self.session];
         // A session can only run when the app is full screen. It will be interrupted in a multi-app layout, introduced in iOS 9,
@@ -1049,6 +1078,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         [[NSNotificationCenter defaultCenter] removeObserver:self];
         [self.session removeObserver:self forKeyPath:@"running" context:SessionRunningContext];
         [self.stillImageOutput removeObserver:self forKeyPath:@"capturingStillImage" context:CapturingStillImageContext];
+        [self.videoDeviceInput.device removeObserver:self forKeyPath:@"adjustingFocus"];
         self.isAddedOberver = NO;
     }
 }
@@ -1075,37 +1105,53 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 
 - (void)subjectAreaDidChange:(NSNotification *)notification
 {
-    //    CGPoint devicePoint = CGPointMake( 0.5, 0.5 );
-    //    [self focusWithMode:AVCaptureFocusModeContinuousAutoFocus exposeWithMode:AVCaptureExposureModeContinuousAutoExposure atDevicePoint:devicePoint monitorSubjectAreaChange:NO];
-    //        //NSLog(@"subjectAreaDidChange");
+    [self resetFocus];
 }
-
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if ( context == CapturingStillImageContext ) {
+    if (context == CapturingStillImageContext)
+    {
+        // Flash/dim preview to indicate shutter action
         BOOL isCapturingStillImage = [change[NSKeyValueChangeNewKey] boolValue];
-        
-        if ( isCapturingStillImage ) {
-            dispatch_async( dispatch_get_main_queue(), ^{
+        if ( isCapturingStillImage )
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
                 self.alpha = 0.0;
                 [UIView animateWithDuration:0.35 animations:^{
                     self.alpha = 1.0;
                 }];
-            } );
+            });
         }
     }
-    else if ( context == SessionRunningContext ) {
-        BOOL isSessionRunning = [change[NSKeyValueChangeNewKey] boolValue];
-        
-        //        dispatch_async( dispatch_get_main_queue(), ^{
-        //            // Only enable the ability to change camera if the device has more than one camera.
-        //            self.cameraButton.enabled = isSessionRunning && ( [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo].count > 1 );
-        //            self.recordButton.enabled = isSessionRunning;
-        //            self.stillButton.enabled = isSessionRunning;
-        //        } );
+    else if ([keyPath isEqualToString:@"adjustingFocus"])
+    {
+        // Note: oldKey is not available (value is always NO it seems) so we only check on newKey
+        BOOL isFocusing = [change[NSKeyValueChangeNewKey] boolValue];
+        if (self.startFocusResetTimerAfterFocusing == YES && !isFocusing && self.resetFocusTimeout > 0)
+        {
+            self.startFocusResetTimerAfterFocusing = NO;
+            
+            // Disengage manual focus after focusTimeout milliseconds
+            NSTimeInterval focusTimeoutSeconds = self.resetFocusTimeout / 1000;
+            self.focusResetTimer = [NSTimer scheduledTimerWithTimeInterval:focusTimeoutSeconds repeats:NO block:^(NSTimer *timer) {
+                [self resetFocus];
+            }];
+        }
     }
-    else {
+    else if (context == SessionRunningContext)
+    {
+//        BOOL isSessionRunning = [change[NSKeyValueChangeNewKey] boolValue];
+//
+//        dispatch_async( dispatch_get_main_queue(), ^{
+//            // Only enable the ability to change camera if the device has more than one camera.
+//            self.cameraButton.enabled = isSessionRunning && ( [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo].count > 1 );
+//            self.recordButton.enabled = isSessionRunning;
+//            self.stillButton.enabled = isSessionRunning;
+//        } );
+    }
+    else
+    {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
 }

--- a/ios/lib/ReactNativeCameraKit/CKCameraManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKCameraManager.m
@@ -30,8 +30,8 @@ RCT_EXPORT_VIEW_PROPERTY(onReadCode, RCTDirectEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(scannerOptions, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(showFrame, BOOL)
-
-
+RCT_EXPORT_VIEW_PROPERTY(resetFocusTimeout, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(resetFocusWhenMotionDetected, BOOL)
 
 RCT_EXPORT_METHOD(checkDeviceCameraAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {

--- a/src/CameraKitCamera.android.js
+++ b/src/CameraKitCamera.android.js
@@ -1,9 +1,9 @@
 import * as _ from 'lodash';
 import React, { Component } from 'react';
 import {
-	requireNativeComponent,
+  requireNativeComponent,
   NativeModules,
-  processColor
+  processColor,
 } from 'react-native';
 
 const NativeCamera = requireNativeComponent('CameraView', null);
@@ -12,17 +12,6 @@ const TORCH_MODE_ON = 'on';
 const TORCH_MODE_CALL_ARG = 'torch';
 
 export default class CameraKitCamera extends React.Component {
-
-  render() {
-    const transformedProps = _.cloneDeep(this.props);
-    _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
-    _.update(transformedProps, 'frameColor', (c) => processColor(c));
-    _.update(transformedProps, 'laserColor', (c) => processColor(c));
-    _.update(transformedProps, 'surfaceColor', (c) => processColor(c));
-
-    return <NativeCamera {...transformedProps}/>
-  }
-
   async logData() {
     console.log('front Camera?', await NativeCameraModule.hasFrontCamera());
     console.log('hasFlash?', await NativeCameraModule.hasFlashForCurrentCamera());
@@ -58,5 +47,15 @@ export default class CameraKitCamera extends React.Component {
 
   static async hasCameraPermission() {
     return await NativeCameraModule.hasCameraPermission();
+  }
+
+  render() {
+    const transformedProps = _.cloneDeep(this.props);
+    _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
+    _.update(transformedProps, 'frameColor', (c) => processColor(c));
+    _.update(transformedProps, 'laserColor', (c) => processColor(c));
+    _.update(transformedProps, 'surfaceColor', (c) => processColor(c));
+
+    return <NativeCamera {...transformedProps}/>;
   }
 }

--- a/src/CameraKitCamera.ios.js
+++ b/src/CameraKitCamera.ios.js
@@ -1,25 +1,17 @@
 import * as _ from 'lodash';
-import React, {Component} from 'react';
+import React from 'react';
 import {
   requireNativeComponent,
   NativeModules,
-  processColor
+  processColor,
 } from 'react-native';
 
 const NativeCamera = requireNativeComponent('CKCamera', null);
 const NativeCameraAction = NativeModules.CKCameraManager;
 
 export default class CameraKitCamera extends React.Component {
-  render() {
-
-    const transformedProps = _.cloneDeep(this.props);
-    _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
-    return <NativeCamera {...transformedProps}/>
-  }
-
   static async checkDeviceCameraAuthorizationStatus() {
     return await NativeCameraAction.checkDeviceCameraAuthorizationStatus();
-
   }
 
   static async requestDeviceCameraAuthorization() {
@@ -40,5 +32,17 @@ export default class CameraKitCamera extends React.Component {
 
   async setTorchMode(torchMode = '') {
     return await NativeCameraAction.setTorchMode(torchMode);
+  }
+
+  render() {
+    const transformedProps = _.cloneDeep(this.props);
+    _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
+    return (
+      <NativeCamera
+        resetFocusTimeout={0}
+        resetFocusWhenMotionDetected
+        {...transformedProps}
+      />
+    );
   }
 }

--- a/src/CameraScreen/CameraKitCameraScreen.android.js
+++ b/src/CameraScreen/CameraKitCameraScreen.android.js
@@ -3,7 +3,6 @@ import {View} from 'react-native';
 import CameraScreenBase from './CameraKitCameraScreenBase';
 
 export default class CameraScreen extends CameraScreenBase {
-
   renderGap() {
     return (
       <View style={{flex: 10, flexDirection: 'column'}}/>

--- a/src/CameraScreen/CameraKitCameraScreen.ios.js
+++ b/src/CameraScreen/CameraKitCameraScreen.ios.js
@@ -3,7 +3,6 @@ import {View} from 'react-native';
 import CameraScreenBase from './CameraKitCameraScreenBase';
 
 export default class CameraScreen extends CameraScreenBase {
-
   render() {
     return (
       <View style={{ flex: 1, backgroundColor: 'black' }} {...this.props}>

--- a/src/CameraScreen/CameraKitCameraScreenStyleObject.android.js
+++ b/src/CameraScreen/CameraKitCameraScreenStyleObject.android.js
@@ -2,29 +2,22 @@ import { Dimensions } from 'react-native';
 const { width, height } = Dimensions.get('window');
 
 const styleObject = {
-    cameraContainer: {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width, height
-    },
-    // bottomButtons: {
-    //     flex: 2,
-    //     backgroundColor: 'transparent',
-    //     flexDirection: 'row',
-    //     justifyContent: 'space-between',
-    //     padding: 10
-    // },
-    bottomButtons: {
-        flex: 2,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        padding: 14
-    },
-    gap: {
-        flex: 10,
-        flexDirection: 'column'
-    },
+  cameraContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width, height,
+  },
+  bottomButtons: {
+    flex: 2,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: 14,
+  },
+  gap: {
+    flex: 10,
+    flexDirection: 'column',
+  },
 };
 
 export default styleObject;

--- a/src/CameraScreen/CameraKitCameraScreenStyleObject.ios.js
+++ b/src/CameraScreen/CameraKitCameraScreenStyleObject.ios.js
@@ -3,15 +3,8 @@ const styleObject = {
     flex: 2,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    padding: 14
+    padding: 14,
   },
-//   bottomContainerGap: {
-//     flex: 1,
-//     flexDirection: 'row',
-//     justifyContent: 'flex-end',
-//     alignItems: 'center',
-//     padding: 10
-//   }
 };
 
 export default styleObject;


### PR DESCRIPTION
This also fixes inability to dismiss tap to focus. Developers now have the option to use either or both of:
- `resetFocusTimeout`
- `resetFocusWhenMotionDetected`

Additions are iOS only. Android's CameraX rework will support the `resetFocusTimeout` feature, also know as "cancelFocus", however won't support `resetFocusWhenMotionDetected` as that is an iOS only feature.