### PR TITLE
Increased photo capture performance, improved photo quality/size

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Attribute         | Values                 | Description
 `flashMode`         |`'on'`/`'off'`/`'auto'` | Camera flash mode (default is `auto`)
 `focusMode`         | `'on'`/`'off'`         | Camera focus mode (default is `on`)
 `zoomMode`          | `'on'`/`'off'`         | Camera zoom mode
-`ratioOverlay`      | `['int':'int', ...]`   | Crop the image to the selected ratio. Example: `['16:9', '1:1', '3:4']`
+`ratioOverlay`      | `['int':'int', ...]`   | Show a guiding overlay in the camera preview for the selected ratio. Does not crop image as of v9.0. Example: `['16:9', '1:1', '3:4']`
 `ratioOverlayColor` |  Color                 | Any color with alpha (default is ```'#ffffff77'```)
 
 ### CameraKitCamera API

--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -138,7 +138,6 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 - (void)dealloc
 {
     [self removeObservers];
-//    NSLog(@"dealloc");
 }
 
 -(PHFetchOptions *)fetchOptions {
@@ -485,8 +484,9 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
             device.flashMode = flashMode;
             [device unlockForConfiguration];
         }
-        else {
-            //NSLog( @"Could not lock device for configuration: %@", error );
+        else
+        {
+            NSLog(@"Could not lock device for configuration: %@", error);
         }
     }
 }
@@ -530,7 +530,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
         // Capture a still image.
         [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:connection completionHandler:^( CMSampleBufferRef imageDataSampleBuffer, NSError *error ) {
             if (!imageDataSampleBuffer) {
-                //NSLog( @"Could not capture still image: %@", error );
+                NSLog(@"Could not capture still image: %@", error);
                 return;
             }
             // The sample buffer is not retained. Create image data before saving the still image to the photo library asynchronously.
@@ -559,7 +559,7 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
                     
                     [CKGalleryManager saveImageToCameraRoll:imageData temporaryFileURL:temporaryFileURL block:^(BOOL success) {
                         if (!success) {
-                            //NSLog( @"Could not save to camera roll");
+                            NSLog(@"Could not save to camera roll");
                             return;
                         }
                         NSString *localIdentifier = [CKGalleryManager getImageLocalIdentifierForFetchOptions:self.fetchOptions];
@@ -651,11 +651,8 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
     NSError *error = nil;
     [data writeToURL:temporaryFileURL options:NSDataWritingAtomic error:&error];
     
-    if ( error ) {
-        //NSLog( @"Error occured while writing image data to a temporary file: %@", error );
-    }
-    else {
-        //NSLog(@"Image Saved - YOU ROCK!");
+    if (error) {
+        NSLog(@"Error occured while writing image data to a temporary file: %@", error);
     }
     return temporaryFileURL;
 }


### PR DESCRIPTION
Re-encoding as JPEG causes files to bloat up. We now take data directly from camera and save it to the library. We also avoid rotating the photo (which may be introduced later behind a flag) to avoid wasting cycles.
These changes mean that the ratioOverlay no longer crops the image which is a little conter-intuitive (an overlay shouldn't change the capture process). We can reintroduce this feature later if we find a need for cropping besides what the community Image Editor library can provide.