### PR TITLE
Fixed duplicate photo storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Prop | Type | Description
 -------- | ----- | ------------
 `resetFocusTimeout`          | Number  | iOS only. Dismiss tap to focus after this many milliseconds. Default `0` (disabled). Example: `5000` is 5 seconds.
 `resetFocusWhenMotionDetected` | Boolean | iOS only. Dismiss tap to focus when focus area content changes. Native iOS feature, see documentation: https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624644-subjectareachangemonitoringenabl?language=objc). Default `true`.
+`saveToCameraRoll` | Boolean | Using the camera roll is slower than using regular files stored in your app. On an iPhone X in debug mode, on a real phone, we measured around 100-150ms processing time to save to the camera roll. *<span style="color: red">**Note:**</span> This only work on real devices. It will hang indefinitly on simulators.*
+`saveToCameraRollWithPhUrl` | Boolean | iOS only. If true, speeds up photo taking by about 5-50ms (measured on iPhone X) by only returning a [rn-cameraroll-compatible](https://github.com/react-native-community/react-native-cameraroll/blob/a09af08f0a46a98b29f6ad470e59d3dc627864a2/ios/RNCAssetsLibraryRequestHandler.m#L36) `ph://..` URL instead of a regular `file://..` URL.
 `cameraOptions`                      | Object  | See `cameraOptions` below
 
 ### cameraOptions
@@ -132,15 +134,13 @@ const isUserAuthorizedCamera = await CameraKitCamera.requestDeviceCameraAuthoriz
 
 otherwise, returns `false`
 
-#### capture - must have the wanted camera capture reference
+#### capture({ ... }) - must have the wanted camera capture reference
 
-Capture image (`shouldSaveToCameraRoll: boolean`)
+Capture image (`{ saveToCameraRoll: boolean }`). Using the camera roll is slower than using regular files stored in your app. On an iPhone X in debug mode, on a real phone, we measured around 100-150ms processing time to save to the camera roll.
 
 ```js
-const image = await this.camera.capture(true);
+const image = await this.camera.capture();
 ```
-
-*<span style="color: red">**Note:**</span> This only work on real devices. It will hang indefinitly on simulators.*
 
 #### setFlashMode - must have the wanted camera capture reference
 

--- a/android/src/main/java/com/wix/RNCameraKit/gallery/NativeGalleryModule.java
+++ b/android/src/main/java/com/wix/RNCameraKit/gallery/NativeGalleryModule.java
@@ -299,11 +299,6 @@ public class NativeGalleryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void saveImageURLToCameraRoll(String imageUrl, final Promise promise) {
-        new SaveImageTask(imageUrl, getReactApplicationContext(), promise, true).execute();
-    }
-
-    @ReactMethod
     public void deleteTempImage(String imageUrl, final Promise promise) {
         boolean success = true;
         String imagePath = imageUrl.replace("file://", "");

--- a/example-ios/CameraKit.xcodeproj/project.pbxproj
+++ b/example-ios/CameraKit.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = S3GLW74Y8N;
+						DevelopmentTeam = 7HJ894LG96;
 					};
 				};
 			};
@@ -145,6 +145,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -241,7 +242,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = S3GLW74Y8N;
+				DEVELOPMENT_TEAM = 7HJ894LG96;
 				INFOPLIST_FILE = CameraKit/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -249,6 +250,7 @@
 					"-ObjC",
 					"-lc++",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = dk.seph.example.CameraKit;
 				PRODUCT_NAME = CameraKit;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -260,7 +262,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = S3GLW74Y8N;
+				DEVELOPMENT_TEAM = 7HJ894LG96;
 				INFOPLIST_FILE = CameraKit/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
@@ -268,6 +270,7 @@
 					"-ObjC",
 					"-lc++",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = dk.seph.example.CameraKit;
 				PRODUCT_NAME = CameraKit;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/ios/lib/ReactNativeCameraKit/CKCamera.h
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.h
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSInteger, CKCameraZoomMode) {
 
 
 // api
-- (void)snapStillImage:(BOOL)shouldSaveToCameraRoll success:(CaptureBlock)block;
+- (void)snapStillImage:(NSDictionary*)options success:(CaptureBlock)block onError:(void (^)(NSString*))onError;
 - (void)changeCamera:(CallbackBlock)block;
 - (void)setFlashMode:(AVCaptureFlashMode)flashMode callback:(CallbackBlock)block;
 - (void)setTorchMode:(AVCaptureTorchMode)torchMode callback:(CallbackBlock)block;

--- a/ios/lib/ReactNativeCameraKit/CKCameraManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKCameraManager.m
@@ -32,6 +32,8 @@ RCT_EXPORT_VIEW_PROPERTY(scannerOptions, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(showFrame, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(resetFocusTimeout, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(resetFocusWhenMotionDetected, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(saveToCameraRoll, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(saveToCameraRollWithPhUrl, BOOL)
 
 RCT_EXPORT_METHOD(checkDeviceCameraAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
@@ -59,16 +61,14 @@ RCT_EXPORT_METHOD(requestDeviceCameraAuthorization:(RCTPromiseResolveBlock)resol
 }
 
 
-RCT_EXPORT_METHOD(capture:(BOOL)shouldSaveToCameraRoll
+RCT_EXPORT_METHOD(capture:(NSDictionary*)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     
-    [self.camera snapStillImage:shouldSaveToCameraRoll success:^(NSDictionary *imageObject) {
-        if (imageObject) {
-            if (resolve) {
-                resolve(imageObject);
-            }
-        }
+    [self.camera snapStillImage:options success:^(NSDictionary *imageObject) {
+        resolve(imageObject);
+    } onError:^(NSString* error) {
+        reject(@"capture_error", error, nil);
     }];
 }
 
@@ -77,9 +77,9 @@ RCT_EXPORT_METHOD(changeCamera:(RCTPromiseResolveBlock)resolve
     
     [self.camera changeCamera:^(BOOL success) {
         if (success) {
-            if (resolve) {
-                resolve([NSNumber numberWithBool:success]);
-            }
+            resolve([NSNumber numberWithBool:success]);
+        } else {
+            reject(@"change_camera_error", @"Unable to change camera", nil);
         }
     }];
 }
@@ -89,9 +89,7 @@ RCT_EXPORT_METHOD(setFlashMode:(CKCameraFlashMode)flashMode
                   reject:(RCTPromiseRejectBlock)reject) {
     
     [self.camera setFlashMode:flashMode callback:^(BOOL success) {
-        if (resolve) {
-            resolve([NSNumber numberWithBool:success]);
-        }
+        resolve([NSNumber numberWithBool:success]);
     }];
 }
 
@@ -100,9 +98,7 @@ RCT_EXPORT_METHOD(setTorchMode:(CKCameraTorchMode)torchMode
                   reject:(RCTPromiseRejectBlock)reject) {
     
     [self.camera setTorchMode:torchMode callback:^(BOOL success) {
-        if (resolve) {
-            resolve([NSNumber numberWithBool:success]);
-        }
+        resolve([NSNumber numberWithBool:success]);
     }];
 }
 

--- a/ios/lib/ReactNativeCameraKit/CKGalleryManager.h
+++ b/ios/lib/ReactNativeCameraKit/CKGalleryManager.h
@@ -26,7 +26,5 @@ typedef void (^SaveBlock)(BOOL success);
 @interface CKGalleryManager : NSObject <RCTBridgeModule>
 
 +(void)deviceGalleryAuthorizationStatus:(CallbackGalleryAuthorizationStatus)callback;
-+(void)saveImageToCameraRoll:(NSData*)imageData temporaryFileURL:(NSURL*)temporaryFileURL block:(SaveBlock)block;
-+(NSString*)getImageLocalIdentifierForFetchOptions:(PHFetchOptions*)fetchOption;
 
 @end

--- a/src/CameraKitCamera.ios.js
+++ b/src/CameraKitCamera.ios.js
@@ -4,6 +4,7 @@ import {
   requireNativeComponent,
   NativeModules,
   processColor,
+  Platform,
 } from 'react-native';
 
 const NativeCamera = requireNativeComponent('CKCamera', null);
@@ -18,8 +19,14 @@ export default class CameraKitCamera extends React.Component {
     return await NativeCameraAction.requestDeviceCameraAuthorization();
   }
 
-  async capture(saveToCameraRoll = true) {
-    return await NativeCameraAction.capture(saveToCameraRoll);
+  capture(options) {
+    if (Platform.OS === 'ios') {
+      return NativeCameraAction.capture(options);
+    }
+    if (Platform.OS === 'android') {
+      // Android has not been updated to use props yet
+      return NativeCameraAction.capture(!!this.props.saveToCameraRoll);
+    }
   }
 
   async changeCamera() {
@@ -38,11 +45,13 @@ export default class CameraKitCamera extends React.Component {
     const transformedProps = _.cloneDeep(this.props);
     _.update(transformedProps, 'cameraOptions.ratioOverlayColor', (c) => processColor(c));
     return (
-      <NativeCamera
-        resetFocusTimeout={0}
-        resetFocusWhenMotionDetected
-        {...transformedProps}
-      />
+      <NativeCamera {...transformedProps} />
     );
   }
 }
+
+CameraKitCamera.defaultProps = {
+  resetFocusTimeout: 0,
+  resetFocusWhenMotionDetected: true,
+  saveToCameraRoll: true,
+};

--- a/src/CameraScreen/CameraKitCameraScreen.android.js
+++ b/src/CameraScreen/CameraKitCameraScreen.android.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import CameraScreenBase from './CameraKitCameraScreenBase';
 

--- a/src/CameraScreen/CameraKitCameraScreen.ios.js
+++ b/src/CameraScreen/CameraKitCameraScreen.ios.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import {View} from 'react-native';
 import CameraScreenBase from './CameraKitCameraScreenBase';
 

--- a/src/CameraScreen/CameraKitCameraScreenBase.js
+++ b/src/CameraScreen/CameraKitCameraScreenBase.js
@@ -9,7 +9,7 @@ import {
   NativeModules,
   Platform,
   SafeAreaView,
-  processColor  
+  processColor,
 } from 'react-native';
 import _ from 'lodash';
 import CameraKitCamera from './../CameraKitCamera';
@@ -41,16 +41,16 @@ export default class CameraScreenBase extends Component {
     this.currentFlashArrayPosition = 0;
     this.flashArray = [{
       mode: FLASH_MODE_AUTO,
-      image: _.get(this.props, 'flashImages.auto')
+      image: _.get(this.props, 'flashImages.auto'),
     },
-      {
-        mode: FLASH_MODE_ON,
-        image: _.get(this.props, 'flashImages.on')
-      },
-      {
-        mode: FLASH_MODE_OFF,
-        image: _.get(this.props, 'flashImages.off')
-      }
+    {
+      mode: FLASH_MODE_ON,
+      image: _.get(this.props, 'flashImages.on'),
+    },
+    {
+      mode: FLASH_MODE_OFF,
+      image: _.get(this.props, 'flashImages.off'),
+    },
     ];
     this.state = {
       captureImages: [],
@@ -61,7 +61,7 @@ export default class CameraScreenBase extends Component {
       ratioArrayPosition: -1,
       imageCaptured: undefined,
       captured: false,
-      scannerOptions : {}
+      scannerOptions: {},
     };
     this.onSetFlash = this.onSetFlash.bind(this);
     this.onSetTorch = this.onSetTorch.bind(this);
@@ -79,7 +79,7 @@ export default class CameraScreenBase extends Component {
       cameraOptions,
       scannerOptions,
       ratios: (ratios || []),
-      ratioArrayPosition: ((ratios.length > 0) ? 0 : -1)
+      ratioArrayPosition: ((ratios.length > 0) ? 0 : -1),
     });
   }
 
@@ -91,7 +91,7 @@ export default class CameraScreenBase extends Component {
     const cameraOptions = this.props.cameraOptions || {
       flashMode: 'auto',
       focusMode: 'on',
-      zoomMode: 'on'
+      zoomMode: 'on',
     };
     if (this.props.cameraRatioOverlay) {
       const overlay = this.props.cameraRatioOverlay;
@@ -112,7 +112,7 @@ export default class CameraScreenBase extends Component {
     if (this.props.colorForScannerFrame) {
       scannerOptions.colorForFrame = processColor(this.props.colorForScannerFrame);
     } else {
-      scannerOptions.colorForFrame = processColor("white");
+      scannerOptions.colorForFrame = processColor('white');
     }
     return scannerOptions;
   }
@@ -125,7 +125,7 @@ export default class CameraScreenBase extends Component {
           source={this.state.flashData.image}
           resizeMode="contain"
         />
-      </TouchableOpacity>
+      </TouchableOpacity>;
   }
 
   renderSwitchCameraButton() {
@@ -137,15 +137,15 @@ export default class CameraScreenBase extends Component {
           resizeMode="contain"
 
         />
-      </TouchableOpacity>
+      </TouchableOpacity>;
   }
 
   renderTopButtons() {
     return !this.props.hideControls && (
-        <SafeAreaView style={styles.topButtons}>
-            {this.renderFlashButton()}
-            {this.renderSwitchCameraButton()}
-        </SafeAreaView>
+      <SafeAreaView style={styles.topButtons}>
+        {this.renderFlashButton()}
+        {this.renderSwitchCameraButton()}
+      </SafeAreaView>
     );
   }
 
@@ -162,6 +162,7 @@ export default class CameraScreenBase extends Component {
               ref={(cam) => this.camera = cam}
               style={{ flex: 1, justifyContent: 'flex-end' }}
               cameraOptions={this.state.cameraOptions}
+              saveToCameraRoll={!this.props.allowCaptureRetake}
               showFrame={this.props.showFrame}
               scanBarcode={this.props.scanBarcode}
               laserColor={this.props.laserColor}
@@ -203,7 +204,7 @@ export default class CameraScreenBase extends Component {
           </View>
 
         </TouchableOpacity>
-      </View >
+      </View >;
   }
 
   renderRatioStrip() {
@@ -227,23 +228,16 @@ export default class CameraScreenBase extends Component {
 
   sendBottomButtonPressedAction(type, captureRetakeMode, image) {
     if (this.props.onBottomButtonPressed) {
-      this.props.onBottomButtonPressed({ type, captureImages: this.state.captureImages, captureRetakeMode, image })
+      this.props.onBottomButtonPressed({ type, captureImages: this.state.captureImages, captureRetakeMode, image });
     }
   }
 
-  async onButtonPressed(type) {
+  onButtonPressed(type) {
     const captureRetakeMode = this.isCaptureRetakeMode();
     if (captureRetakeMode) {
       if (type === 'left') {
         GalleryManager.deleteTempImage(this.state.imageCaptured.uri);
         this.setState({ imageCaptured: undefined });
-      }
-      else if (type === 'right') {
-        const result = await GalleryManager.saveImageURLToCameraRoll(this.state.imageCaptured.uri);
-        const savedImage = { ...this.state.imageCaptured, ...result }; // Note: Can't just return 'result' as on iOS not all data is returned by the native call (just the ID).
-        this.setState({ imageCaptured: undefined, captureImages: _.concat(this.state.captureImages, savedImage) }, () => {
-          this.sendBottomButtonPressedAction(type, captureRetakeMode);
-        });
       }
     } else {
       this.sendBottomButtonPressedAction(type, captureRetakeMode);
@@ -251,13 +245,10 @@ export default class CameraScreenBase extends Component {
   }
 
   renderBottomButton(type) {
-    let showButton = true;
-    if (type === 'right') {
-      showButton = this.state.captureImages.length || this.isCaptureRetakeMode();
-    }
+    const showButton = true;
     if (showButton) {
       const buttonNameSuffix = this.isCaptureRetakeMode() ? 'CaptureRetakeButtonText' : 'ButtonText';
-      const buttonText = _(this.props).get(`actions.${type}${buttonNameSuffix}`)
+      const buttonText = _(this.props).get(`actions.${type}${buttonNameSuffix}`);
       return (
         <TouchableOpacity
           style={[styles.bottomButton, { justifyContent: type === 'left' ? 'flex-start' : 'flex-end' }]}
@@ -278,7 +269,6 @@ export default class CameraScreenBase extends Component {
       <SafeAreaView style={[styles.bottomButtons, { backgroundColor: '#ffffff00' }]}>
         {this.renderBottomButton('left')}
         {this.renderCaptureButton()}
-        {this.renderBottomButton('right')}
       </SafeAreaView>
     );
   }
@@ -294,15 +284,14 @@ export default class CameraScreenBase extends Component {
     this.camera.setFlashMode(newFlashData.mode);
   }
 
-  async onSetTorch() {
+  onSetTorch() {
     const newTorchData = !this.state.torchData;
     this.setState({ torchData: newTorchData });
-    newTorchData ? this.camera.setTorchMode(TORCH_MODE_ON) : this.camera.setTorchMode(TORCH_MODE_OFF); 
+    newTorchData ? this.camera.setTorchMode(TORCH_MODE_ON) : this.camera.setTorchMode(TORCH_MODE_OFF);
   }
 
   async onCaptureImagePressed() {
-    const shouldSaveToCameraRoll = !this.props.allowCaptureRetake;
-    const image = await this.camera.capture(shouldSaveToCameraRoll);
+    const image = await this.camera.capture();
 
     if (this.props.allowCaptureRetake) {
       this.setState({ imageCaptured: image });
@@ -329,7 +318,7 @@ import styleObject from './CameraKitCameraScreenStyleObject';
 const styles = StyleSheet.create(_.merge(styleObject, {
   textStyle: {
     color: 'white',
-    fontSize: 20
+    fontSize: 20,
   },
   ratioBestText: {
     color: 'white',
@@ -337,18 +326,18 @@ const styles = StyleSheet.create(_.merge(styleObject, {
   },
   ratioText: {
     color: '#ffc233',
-    fontSize: 18
+    fontSize: 18,
   },
   topButtons: {
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingTop: 8,
-    paddingBottom: 0
+    paddingBottom: 0,
   },
   cameraContainer: {
     flex: 10,
-    flexDirection: 'column'
+    flexDirection: 'column',
   },
   captureButtonContainer: {
     flex: 1,
@@ -362,19 +351,19 @@ const styles = StyleSheet.create(_.merge(styleObject, {
     bottom: 0,
     right: 0,
     justifyContent: 'center',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   bottomButton: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 10
+    padding: 10,
   },
   bottomContainerGap: {
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'flex-end',
     alignItems: 'center',
-    padding: 10
-  }
+    padding: 10,
+  },
 }));


### PR DESCRIPTION
Breaking change: shouldSaveToCameraRoll is now a prop on <CKCamera /> instead of a function argument
Fixed: Instead of storing a temporary file, allow capturing directly to photo library and use PHAsset identifiers.
PH identifiers allow seamless loading when combined with the rn-community-cameraroll library